### PR TITLE
ci: run test on multible python versions

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -9,7 +9,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v2
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.7]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Lint with flake8
         run: |
           python -m pip install --upgrade pip
@@ -29,9 +29,13 @@ jobs:
           --statistics --exclude .git,__pycache__,__init__.py,test
   unittests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - name: start the app & run unit tests
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: start the app & run unit tests with python ${{ matrix.python-version }}
         shell: bash
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Summary : 
Run CI test on multible python versions [3.6, 3.7, 3.8, 3.9, 3.10]